### PR TITLE
Resolves eclipse-ee4j#56 At URLPatternSpec.setURLPatternArray, we nee…

### DIFF
--- a/api/src/main/java/javax/security/jacc/URLPatternSpec.java
+++ b/api/src/main/java/javax/security/jacc/URLPatternSpec.java
@@ -304,7 +304,7 @@ class URLPatternSpec extends URLPattern {
                     switch (urlPatternArray[i].patternType()) {
                     case URLPattern.PT_PREFIX:
                         if (firstType == URLPattern.PT_PREFIX) {
-                            if (super.equals(urlPatternArray[i]) || !super.implies(urlPatternArray[i])) {
+                            if (super.equals(urlPatternArray[i]) || super.implies(urlPatternArray[i])) {
                                 throw new IllegalArgumentException("Invalid prefix pattern in URLPatternList");
                             }
                         }


### PR DESCRIPTION
…d to verify if super.implies(urlPatternArray[i] to define if we have an invalid prefix pattern